### PR TITLE
Auto finish all hidden child quests + QuestListUpdateNotify queue deprecated

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -35,7 +35,7 @@ public class GameQuest {
     @Getter private int subQuestId;
     @Getter private int mainQuestId;
     @Getter @Setter
-    private QuestState state;
+    public QuestState state;
 
     @Getter @Setter private int startTime;
     @Getter @Setter private int acceptTime;
@@ -156,6 +156,8 @@ public class GameQuest {
         this.state = QuestState.QUEST_STATE_FINISHED;
         this.finishTime = Utils.getCurrentSeconds();
 
+        getOwner().sendPacket(new PacketQuestListUpdateNotify(this));
+
         if (getQuestData().finishParent()) {
             // This quest finishes the questline - the main quest will also save the quest to db, so we don't have to call save() here
             getMainQuest().finish();
@@ -183,13 +185,17 @@ public class GameQuest {
         this.state = QuestState.QUEST_STATE_FAILED;
         this.finishTime = Utils.getCurrentSeconds();
 
+        getOwner().sendPacket(new PacketQuestListUpdateNotify(this));
+
         //Some subQuests have conditions that subQuests fail (even from different MainQuests)
         getOwner().getQuestManager().queueEvent(QuestTrigger.QUEST_CONTENT_QUEST_STATE_EQUAL, this.subQuestId, this.state.getValue(),0,0,0);
         getOwner().getQuestManager().queueEvent(QuestTrigger.QUEST_COND_STATE_EQUAL, this.subQuestId, this.state.getValue(),0,0,0);
 
         getQuestData().getFailExec().forEach(e -> getOwner().getServer().getQuestSystem().triggerExec(this, e, e.getParam()));
 
+        Grasscutter.getLogger().debug("Quest {} is failed", subQuestId);
     }
+
     // Return true if it did the rewind
     public boolean rewind(boolean notifyDelete) {
         getMainQuest().getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() > this.getQuestData().getOrder()).forEach(q -> {


### PR DESCRIPTION
Auto finish all hidden child quests when finishing the main quest, QuestListUpdateNotify queue deprecated because if no event triggers = no packets to client with PacketQuestListUpdateNotify (in case of manual finish quest by id)

## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.