### PR TITLE
Updated with how talks are handle

### DIFF
--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -112,6 +112,7 @@ public class GameData {
     @Getter private static final Int2ObjectMap<RewardData> rewardDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<RewardPreviewData> rewardPreviewDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<SceneData> sceneDataMap = new Int2ObjectLinkedOpenHashMap<>();
+    @Getter private static final Int2ObjectMap<TalkConfigData> talkConfigDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<TowerFloorData> towerFloorDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<TowerLevelData> towerLevelDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<TowerScheduleData> towerScheduleDataMap = new Int2ObjectOpenHashMap<>();

--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -106,6 +106,7 @@ public class GameData {
     @Getter private static final Int2ObjectMap<PlayerLevelData> playerLevelDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<ProudSkillData> proudSkillDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<QuestData> questDataMap = new Int2ObjectOpenHashMap<>();
+    @Getter private static final Int2ObjectMap<QuestGlobalVarData> questGlobalVarDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<ReliquaryAffixData> reliquaryAffixDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<ReliquaryMainPropData> reliquaryMainPropDataMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<ReliquarySetData> reliquarySetDataMap = new Int2ObjectOpenHashMap<>();

--- a/src/main/java/emu/grasscutter/data/excels/QuestGlobalVarData.java
+++ b/src/main/java/emu/grasscutter/data/excels/QuestGlobalVarData.java
@@ -1,0 +1,22 @@
+package emu.grasscutter.data.excels;
+
+import emu.grasscutter.data.GameResource;
+import emu.grasscutter.data.ResourceType;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.FieldDefaults;;
+
+@ResourceType(name = "QuestGlobalVarConfigData.json")
+@EqualsAndHashCode(callSuper=false)
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuestGlobalVarData extends GameResource {
+    int id;
+    int defaultValue;
+
+    @Override
+    public int getId() {
+        return this.id;
+    }
+}

--- a/src/main/java/emu/grasscutter/data/excels/TalkConfigData.java
+++ b/src/main/java/emu/grasscutter/data/excels/TalkConfigData.java
@@ -1,0 +1,45 @@
+package emu.grasscutter.data.excels;
+
+import com.google.gson.annotations.SerializedName;
+import emu.grasscutter.data.GameResource;
+import emu.grasscutter.data.ResourceType;
+import emu.grasscutter.game.talk.TalkExec;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@ResourceType(name = "TalkExcelConfigData.json")
+@EqualsAndHashCode(callSuper=false)
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TalkConfigData extends GameResource {
+    @SerializedName(value="id", alternate={"_id"})
+    int id;
+    @SerializedName(value="finishExec", alternate={"_finishExec"})
+    List<TalkExecParam> finishExec;
+    @SerializedName(value="questId", alternate={"_questId"})
+    int questId;
+
+    @Override
+    public int getId() {
+        return this.id;
+    }
+
+    @Override
+    public void onLoad() {
+        this.finishExec = this.finishExec == null ? List.of() : 
+            this.finishExec.stream().filter(x -> x.getType() != null).toList();
+    }
+
+    @Data
+    public static class TalkExecParam {
+        @SerializedName(value="type", alternate={"_type"})
+        TalkExec type;
+        @SerializedName(value="param", alternate={"_param"})
+        String[] param;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -43,6 +43,7 @@ import emu.grasscutter.game.quest.QuestManager;
 import emu.grasscutter.game.quest.enums.QuestCond;
 import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.game.shop.ShopLimit;
+import emu.grasscutter.game.talk.TalkManager;
 import emu.grasscutter.game.tower.TowerData;
 import emu.grasscutter.game.tower.TowerManager;
 import emu.grasscutter.game.world.Scene;
@@ -167,6 +168,7 @@ public class Player {
     @Getter private transient ActivityManager activityManager;
     @Getter private transient PlayerBuffManager buffManager;
     @Getter private transient PlayerProgressManager progressManager;
+    @Getter private transient TalkManager talkManager;
 
     // Manager data (Save-able to the database)
     private PlayerProfile playerProfile;  // Getter has null-check
@@ -273,6 +275,7 @@ public class Player {
         this.furnitureManager = new FurnitureManager(this);
         this.cookingManager = new CookingManager(this);
         this.cookingCompoundManager=new CookingCompoundManager(this);
+        this.talkManager = new TalkManager(this);
     }
 
     // On player creation

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1315,6 +1315,7 @@ public class Player {
         session.send(new PacketFinishedParentQuestNotify(this));
         session.send(new PacketBattlePassAllDataNotify(this));
         session.send(new PacketQuestListNotify(this));
+        session.send(new PacketQuestGlobalVarNotify(this));
         session.send(new PacketCodexDataFullNotify(this));
         session.send(new PacketAllWidgetDataNotify(this));
         session.send(new PacketWidgetGadgetAllDataNotify());

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -21,6 +21,7 @@ import emu.grasscutter.net.proto.ParentQuestOuterClass.ParentQuest;
 import emu.grasscutter.server.packet.send.PacketCodexDataUpdateNotify;
 import emu.grasscutter.server.packet.send.PacketFinishedParentQuestUpdateNotify;
 import emu.grasscutter.server.packet.send.PacketQuestProgressUpdateNotify;
+import emu.grasscutter.server.packet.send.PacketQuestUpdateQuestVarNotify;
 import emu.grasscutter.utils.Position;
 import lombok.Getter;
 import lombok.val;
@@ -113,6 +114,7 @@ public class GameMainQuest {
         this.questManager.queueEvent(QuestContent.QUEST_CONTENT_QUEST_VAR_EQUAL, index, value);
         this.questManager.queueEvent(QuestContent.QUEST_CONTENT_QUEST_VAR_GREATER, index, value);
         this.questManager.queueEvent(QuestContent.QUEST_CONTENT_QUEST_VAR_LESS, index, value);
+        this.getOwner().sendPacket(new PacketQuestUpdateQuestVarNotify(this.getParentQuestId(), this.questVars));
     }
 
 

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -89,18 +89,30 @@ public class GameMainQuest {
         int previousValue = this.questVars[i];
         this.questVars[i] = value;
         Grasscutter.getLogger().debug("questVar {} value changed from {} to {}", i, previousValue, value);
+        triggerQuestVarAction(i, this.questVars[i]);
     }
 
     public void incQuestVar(int i, int inc) {
         int previousValue = this.questVars[i];
         this.questVars[i] += inc;
         Grasscutter.getLogger().debug("questVar {} value incremented from {} to {}", i, previousValue, previousValue + inc);
+        triggerQuestVarAction(i, this.questVars[i]);
     }
 
     public void decQuestVar(int i, int dec) {
         int previousValue = this.questVars[i];
         this.questVars[i] -= dec;
         Grasscutter.getLogger().debug("questVar {} value decremented from {} to {}", i, previousValue, previousValue - dec);
+        triggerQuestVarAction(i, this.questVars[i]);
+    }
+
+    public void triggerQuestVarAction(int index, int value) {
+        this.questManager.queueEvent(QuestCond.QUEST_COND_QUEST_VAR_EQUAL, index, value);
+        this.questManager.queueEvent(QuestCond.QUEST_COND_QUEST_VAR_GREATER, index, value);
+        this.questManager.queueEvent(QuestCond.QUEST_COND_QUEST_VAR_LESS, index, value);
+        this.questManager.queueEvent(QuestContent.QUEST_CONTENT_QUEST_VAR_EQUAL, index, value);
+        this.questManager.queueEvent(QuestContent.QUEST_CONTENT_QUEST_VAR_GREATER, index, value);
+        this.questManager.queueEvent(QuestContent.QUEST_CONTENT_QUEST_VAR_LESS, index, value);
     }
 
 

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -162,6 +162,7 @@ public class QuestManager extends BasePlayerManager {
         queueEvent(QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_EQUAL, variable, value);
         queueEvent(QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_GREATER, variable, value);
         queueEvent(QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_LESS, variable, value);
+        getPlayer().sendPacket(new PacketQuestGlobalVarNotify(getPlayer()));
     }
 
     public GameMainQuest getMainQuestById(int mainQuestId) {

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentCompleteAnyTalk.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentCompleteAnyTalk.java
@@ -5,7 +5,7 @@ import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestValueContent;
 import lombok.val;
 
-import java.util.Arrays;
+import java.util.Stream;
 
 import static emu.grasscutter.game.quest.enums.QuestContent.QUEST_CONTENT_COMPLETE_ANY_TALK;
 
@@ -14,19 +14,8 @@ public class ContentCompleteAnyTalk extends BaseContent {
 
     @Override
     public boolean execute(GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        val talkId = params[0];
-        val conditionTalk = Arrays.stream(condition.getParamStr().split(","))
-            .mapToInt(Integer::parseInt)
-            .toArray();
-        return Arrays.stream(conditionTalk).anyMatch(tids -> tids == talkId)
-            || Arrays.stream(conditionTalk).anyMatch(tids -> {
-            val checkMainQuest = quest.getOwner().getQuestManager().getMainQuestByTalkId(tids);
-            if (checkMainQuest == null) {
-                return false;
-            }
-            val talkData = checkMainQuest.getTalks().get(talkId);
-            return talkData != null;
-        });
+        return Stream.of(condition.getParamStr().split(",")).mapToInt(Integer::parseInt).anyMatch(talkId -> 
+            GameData.getTalkConfigDataMap().get(params[0]) != null && talkId == params[0]);
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentCompleteTalk.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentCompleteTalk.java
@@ -1,5 +1,7 @@
 package emu.grasscutter.game.quest.content;
 
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestValueContent;
@@ -12,13 +14,6 @@ public class ContentCompleteTalk extends BaseContent {
 
     @Override
     public boolean execute(GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        val talkId = condition.getParam()[0];
-        val checkMainQuest = quest.getOwner().getQuestManager().getMainQuestByTalkId(talkId);
-        if (checkMainQuest == null) {
-            return false;
-        }
-
-        val talkData = checkMainQuest.getTalks().get(talkId);
-        return talkData != null;
+        return condition.getParam()[0] == params[0] && GameData.getTalkConfigDataMap().get(condition.getParam()[0]) != null;
     }
 }

--- a/src/main/java/emu/grasscutter/game/talk/TalkExec.java
+++ b/src/main/java/emu/grasscutter/game/talk/TalkExec.java
@@ -1,0 +1,56 @@
+package emu.grasscutter.game.talk;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public enum TalkExec{
+    TALK_EXEC_NONE (0),
+    TALK_EXEC_SET_GADGET_STATE (1),
+    TALK_EXEC_SET_GAME_TIME (2),
+    TALK_EXEC_NOTIFY_GROUP_LUA (3),
+    TALK_EXEC_SET_DAILY_TASK_VAR (4),
+    TALK_EXEC_INC_DAILY_TASK_VAR (5),
+    TALK_EXEC_DEC_DAILY_TASK_VAR (6),
+    TALK_EXEC_SET_QUEST_VAR (7),
+    TALK_EXEC_INC_QUEST_VAR (8),
+    TALK_EXEC_DEC_QUEST_VAR (9),
+    TALK_EXEC_SET_QUEST_GLOBAL_VAR (10),
+    TALK_EXEC_INC_QUEST_GLOBAL_VAR (11),
+    TALK_EXEC_DEC_QUEST_GLOBAL_VAR (12),
+    TALK_EXEC_TRANS_SCENE_DUMMY_POINT (13),
+    TALK_EXEC_SAVE_TALK_ID (14);
+
+	private final int value;
+
+	TalkExec(int id) {
+		this.value = id;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+    private static final Int2ObjectMap<TalkExec> execMap = new Int2ObjectOpenHashMap<>();
+    private static final Map<String, TalkExec> execStringMap = new HashMap<>();
+
+    static {
+        Stream.of(values())
+            .filter(e -> e.name().startsWith("TALK_EXEC_"))
+            .forEach(e -> {
+            execMap.put(e.getValue(), e);
+            execStringMap.put(e.name(), e);
+        });
+    }
+
+    public static TalkExec getExecByValue(int value) {
+        return execMap.getOrDefault(value, TALK_EXEC_NONE);
+    }
+
+    public static TalkExec getExecByName(String name) {
+        return execStringMap.getOrDefault(name, TALK_EXEC_NONE);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/TalkExecHandler.java
+++ b/src/main/java/emu/grasscutter/game/talk/TalkExecHandler.java
@@ -1,0 +1,11 @@
+package emu.grasscutter.game.talk;
+
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+
+public abstract class TalkExecHandler {
+
+	public abstract void execute(Player player, TalkConfigData talkData, TalkExecParam execParam);
+
+}

--- a/src/main/java/emu/grasscutter/game/talk/TalkManager.java
+++ b/src/main/java/emu/grasscutter/game/talk/TalkManager.java
@@ -1,0 +1,31 @@
+package emu.grasscutter.game.talk;
+
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.game.player.BasePlayerManager;
+import emu.grasscutter.game.player.Player;
+
+import lombok.Getter;
+
+import static emu.grasscutter.game.quest.enums.QuestContent.QUEST_CONTENT_COMPLETE_ANY_TALK;
+import static emu.grasscutter.game.quest.enums.QuestContent.QUEST_CONTENT_COMPLETE_TALK;
+import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_COMPLETE_TALK;
+
+public class TalkManager extends BasePlayerManager {
+    @Getter private final Player player;
+
+    public TalkManager(Player player) {
+        super(player);
+        this.player = player;
+    }
+
+    public void triggerTalkAction(int talkId) {
+        TalkConfigData talkData = GameData.getTalkConfigDataMap().get(talkId);
+        if (talkData == null || talkData.getFinishExec().isEmpty()) return;
+
+        talkData.getFinishExec().forEach(e -> getPlayer().getServer().getTalkSystem().triggerExec(getPlayer(), talkData, e));
+        getPlayer().getQuestManager().queueEvent(QUEST_CONTENT_COMPLETE_ANY_TALK, talkId);
+        getPlayer().getQuestManager().queueEvent(QUEST_CONTENT_COMPLETE_TALK, talkId);
+        getPlayer().getQuestManager().queueEvent(QUEST_COND_COMPLETE_TALK, talkId);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/TalkSystem.java
+++ b/src/main/java/emu/grasscutter/game/talk/TalkSystem.java
@@ -1,0 +1,66 @@
+package emu.grasscutter.game.talk;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.server.game.BaseGameSystem;
+import emu.grasscutter.server.game.GameServer;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.reflections.Reflections;
+
+@SuppressWarnings("unchecked")
+public class TalkSystem extends BaseGameSystem {
+    private final Int2ObjectMap<TalkExecHandler> execHandlers;
+
+    public TalkSystem(GameServer server) {
+        super(server);
+
+        this.execHandlers = new Int2ObjectOpenHashMap<>();
+
+        this.registerHandlers();
+    }
+
+    public void registerHandlers() {
+        this.registerHandlers(this.execHandlers, "emu.grasscutter.game.talk.exec", TalkExecHandler.class);
+    }
+
+    public <T> void registerHandlers(Int2ObjectMap<T> map, String packageName, Class<T> clazz) {
+        Reflections reflections = new Reflections(packageName);
+        var handlerClasses = reflections.getSubTypesOf(clazz);
+
+        for (var obj : handlerClasses) {
+            this.registerPacketHandler(map, obj);
+        }
+    }
+
+    public <T> void registerPacketHandler(Int2ObjectMap<T> map, Class<? extends T> handlerClass) {
+        try {
+            int value = 0;
+            if (handlerClass.isAnnotationPresent(TalkValueExec.class)) {
+                TalkValueExec opcode = handlerClass.getAnnotation(TalkValueExec.class);
+                value = opcode.value().getValue();
+            } else {
+                return;
+            }
+
+            if (value <= 0) return;
+
+            map.put(value, handlerClass.getDeclaredConstructor().newInstance());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+	public void triggerExec(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+		TalkExecHandler handler = execHandlers.get(execParam.getType().getValue());
+
+        if (handler == null) {
+            Grasscutter.getLogger().debug("Could not trigger talk exec {} at {}", execParam.getType().getValue(), talkData.getId());
+            return;
+        }
+
+		handler.execute(player, talkData, execParam);
+	}
+}

--- a/src/main/java/emu/grasscutter/game/talk/TalkValueExec.java
+++ b/src/main/java/emu/grasscutter/game/talk/TalkValueExec.java
@@ -1,0 +1,10 @@
+package emu.grasscutter.game.talk;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TalkValueExec {
+    TalkExec value();
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecDecQuestGlobalVar.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecDecQuestGlobalVar.java
@@ -1,0 +1,21 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+
+@TalkValueExec(TalkExec.TALK_EXEC_DEC_QUEST_GLOBAL_VAR)
+public class ExecDecQuestGlobalVar extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        if (execParam.getParam().length < 2) return;
+
+        player.getQuestManager().decQuestGlobalVarValue(
+            Integer.parseInt(execParam.getParam()[0]),
+            Integer.parseInt(execParam.getParam()[1])
+        );
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecDecQuestVar.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecDecQuestVar.java
@@ -1,0 +1,28 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.quest.GameMainQuest;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+
+@TalkValueExec(TalkExec.TALK_EXEC_DEC_QUEST_VAR)
+public class ExecDecQuestVar extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        if (execParam.getParam().length < 3) return;
+
+        GameMainQuest mainQuest = player.getQuestManager().getMainQuestById(
+            Integer.parseInt(execParam.getParam()[2])
+        );
+        if (mainQuest == null) return;
+
+        mainQuest.decQuestVar(
+            Integer.parseInt(execParam.getParam()[0]),
+            Integer.parseInt(execParam.getParam()[1])
+        );
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecIncQuestGlobalVar.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecIncQuestGlobalVar.java
@@ -1,0 +1,21 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+
+@TalkValueExec(TalkExec.TALK_EXEC_INC_QUEST_GLOBAL_VAR)
+public class ExecIncQuestGlobalVar extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        if (execParam.getParam().length < 2) return;
+
+        player.getQuestManager().incQuestGlobalVarValue(
+            Integer.parseInt(execParam.getParam()[0]),
+            Integer.parseInt(execParam.getParam()[1])
+        );
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecIncQuestVar.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecIncQuestVar.java
@@ -1,0 +1,28 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.quest.GameMainQuest;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+
+@TalkValueExec(TalkExec.TALK_EXEC_INC_QUEST_VAR)
+public class ExecIncQuestVar extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        if (execParam.getParam().length < 3) return;
+
+        GameMainQuest mainQuest = player.getQuestManager().getMainQuestById(
+            Integer.parseInt(execParam.getParam()[2])
+        );
+        if (mainQuest == null) return;
+
+        mainQuest.incQuestVar(
+            Integer.parseInt(execParam.getParam()[0]),
+            Integer.parseInt(execParam.getParam()[1])
+        );
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecSetGameTime.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecSetGameTime.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+
+@TalkValueExec(TalkExec.TALK_EXEC_SET_GAME_TIME)
+public class ExecSetGameTime extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        if (execParam.getParam().length < 1) return;
+
+        player.getWorld().changeTime(Integer.parseInt(execParam.getParam()[0]), 0);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecSetQuestGlobalVar.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecSetQuestGlobalVar.java
@@ -1,0 +1,21 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+
+@TalkValueExec(TalkExec.TALK_EXEC_SET_QUEST_GLOBAL_VAR)
+public class ExecSetQuestGlobalVar extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        if (execParam.getParam().length < 2) return;
+
+        player.getQuestManager().setQuestGlobalVarValue(
+            Integer.parseInt(execParam.getParam()[0]),
+            Integer.parseInt(execParam.getParam()[1])
+        );
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecSetQuestVar.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecSetQuestVar.java
@@ -1,0 +1,28 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.quest.GameMainQuest;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+
+@TalkValueExec(TalkExec.TALK_EXEC_SET_QUEST_VAR)
+public class ExecSetQuestVar extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        if (execParam.getParam().length < 3) return;
+
+        GameMainQuest mainQuest = player.getQuestManager().getMainQuestById(
+            Integer.parseInt(execParam.getParam()[2])
+        );
+        if (mainQuest == null) return;
+
+        mainQuest.setQuestVar(
+            Integer.parseInt(execParam.getParam()[0]),
+            Integer.parseInt(execParam.getParam()[1])
+        );
+    }
+}

--- a/src/main/java/emu/grasscutter/game/talk/exec/ExecTransSceneDummyPoint.java
+++ b/src/main/java/emu/grasscutter/game/talk/exec/ExecTransSceneDummyPoint.java
@@ -1,0 +1,46 @@
+package emu.grasscutter.game.talk.exec;
+
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.binout.ScriptSceneData;
+import emu.grasscutter.data.excels.TalkConfigData;
+import emu.grasscutter.data.excels.TalkConfigData.TalkExecParam;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.talk.TalkExec;
+import emu.grasscutter.game.talk.TalkExecHandler;
+import emu.grasscutter.game.talk.TalkValueExec;
+import emu.grasscutter.utils.Position;
+
+import java.util.Map;
+import java.util.List;
+
+import static emu.grasscutter.game.quest.enums.QuestContent.QUEST_CONTENT_ANY_MANUAL_TRANSPORT;
+
+@TalkValueExec(TalkExec.TALK_EXEC_TRANS_SCENE_DUMMY_POINT)
+public class ExecTransSceneDummyPoint extends TalkExecHandler {
+    @Override
+    public void execute(Player player, TalkConfigData talkData, TalkExecParam execParam) {
+        // param[0] == sceneid, param[1] == position
+        if (execParam.getParam().length < 2) return;
+
+        ScriptSceneData fullGlobals = GameData.getScriptSceneDataMap().get("flat.luas.scenes.full_globals.lua.json");
+        if (fullGlobals == null) return;
+
+        ScriptSceneData.ScriptObject dummyPointScript = fullGlobals.getScriptObjectList()
+            .get(execParam.getParam()[0] + "/scene" + execParam.getParam()[0] + "_dummy_points.lua");
+        if (dummyPointScript == null) return;
+
+        Map<String, List<Float>> dummyPointMap = dummyPointScript.getDummyPoints();
+        if (dummyPointMap == null) return;
+
+        List<Float> transmitPosPos = dummyPointMap.get(execParam.getParam()[1] + ".pos");
+        // List<Float> transmitPosRot = dummyPointMap.get(e.getParam()[1] + ".rot"); would be useful when transportation consider rotation
+        if (transmitPosPos == null || transmitPosPos.isEmpty()) return;
+
+        player.getWorld().transferPlayerToScene(
+            player, 
+            Integer.parseInt(execParam.getParam()[0]), 
+            new Position(transmitPosPos.get(0), transmitPosPos.get(1), transmitPosPos.get(2)));
+
+        player.getQuestManager().queueEvent(QUEST_CONTENT_ANY_MANUAL_TRANSPORT);
+    }
+}

--- a/src/main/java/emu/grasscutter/server/game/GameServer.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServer.java
@@ -23,6 +23,7 @@ import emu.grasscutter.game.shop.ShopSystem;
 import emu.grasscutter.game.systems.AnnouncementSystem;
 import emu.grasscutter.game.systems.InventorySystem;
 import emu.grasscutter.game.systems.MultiplayerSystem;
+import emu.grasscutter.game.talk.TalkSystem;
 import emu.grasscutter.game.tower.TowerSystem;
 import emu.grasscutter.game.world.World;
 import emu.grasscutter.game.world.WorldDataSystem;
@@ -69,6 +70,7 @@ public final class GameServer extends KcpServer {
     private final TowerSystem towerSystem;
     private final AnnouncementSystem announcementSystem;
     private final QuestSystem questSystem;
+    private final TalkSystem talkSystem;
 
     // Extra
     private final ServerTaskScheduler scheduler;
@@ -122,6 +124,7 @@ public final class GameServer extends KcpServer {
         this.battlePassSystem = new BattlePassSystem(this);
         this.announcementSystem = new AnnouncementSystem(this);
         this.questSystem = new QuestSystem(this);
+        this.talkSystem = new TalkSystem(this);
 
         // Chata manager
         this.chatManager = new ChatSystem(this);

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerNpcTalkReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerNpcTalkReq.java
@@ -19,37 +19,7 @@ public class HandlerNpcTalkReq extends PacketHandler {
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         NpcTalkReq req = NpcTalkReq.parseFrom(payload);
 
-        //Check if mainQuest exists
-        //remove last 2 digits to get a mainQuestId
-        int talkId = req.getTalkId();
-        int mainQuestId = GameData.getQuestTalkMap().getOrDefault(talkId, talkId / 100);
-        MainQuestData mainQuestData = GameData.getMainQuestDataMap().get(mainQuestId);
-
-        if (mainQuestData != null) {
-            // This talk is associated with a quest. Handle it.
-            // If the quest has no talk data defined on it, create one.
-            TalkData talkForQuest = new TalkData(talkId, "");
-            if (mainQuestData.getTalks() != null) {
-                val talks = mainQuestData.getTalks().stream().filter(p -> p.getId() == talkId).toList();
-
-                if (talks.size() > 0) {
-                    talkForQuest = talks.get(0);
-                }
-            }
-
-            // Add to the list of done talks for this quest.
-            val questManager = session.getPlayer().getQuestManager();
-            val mainQuest = questManager.getMainQuestByTalkId(talkId);
-            if (mainQuest != null) {
-                mainQuest.getTalks().put(talkId, talkForQuest);
-            }
-
-            // Fire quest triggers.
-            questManager.queueEvent(QuestContent.QUEST_CONTENT_COMPLETE_ANY_TALK, talkId, 0, 0);
-            questManager.queueEvent(QuestContent.QUEST_CONTENT_COMPLETE_TALK, talkId, 0);
-            questManager.queueEvent(QuestContent.QUEST_CONTENT_FINISH_PLOT, talkId, 0);
-            questManager.queueEvent(QuestCond.QUEST_COND_COMPLETE_TALK, talkId, 0);
-        }
+        session.getPlayer().getTalkManager().triggerTalkAction(req.getTalkId());
 
         session.send(new PacketNpcTalkRsp(req.getNpcEntityId(), req.getTalkId(), req.getEntityId()));
     }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestGlobalVarNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestGlobalVarNotify.java
@@ -1,0 +1,23 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.QuestGlobalVarNotifyOuterClass.QuestGlobalVarNotify;
+import emu.grasscutter.net.proto.QuestGlobalVarOuterClass.QuestGlobalVar;
+
+
+public class PacketQuestGlobalVarNotify extends BasePacket {
+	
+	public PacketQuestGlobalVarNotify(Player player) {
+		super(PacketOpcodes.QuestGlobalVarNotify);
+		this.setData(QuestGlobalVarNotify.newBuilder()
+			.addAllVarList(player.getQuestGlobalVariables().entrySet().stream()
+				.map(e -> QuestGlobalVar.newBuilder()
+					.setKey(e.getKey())
+					.setValue(e.getValue())
+					.build())
+				.toList())
+			.build());
+	}	
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestUpdateQuestVarNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestUpdateQuestVarNotify.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.QuestUpdateQuestVarNotifyOuterClass.QuestUpdateQuestVarNotify;
+
+import java.util.stream.IntStream;
+
+public class PacketQuestUpdateQuestVarNotify extends BasePacket {
+	
+	public PacketQuestUpdateQuestVarNotify(int mainQuestId, int... questVars) {
+		super(PacketOpcodes.QuestUpdateQuestVarNotify);
+		this.setData(QuestUpdateQuestVarNotify.newBuilder()
+			.setParentQuestId(mainQuestId)
+			.addAllQuestVar(IntStream.of(questVars).boxed().toList())
+			.build());
+	}	
+}


### PR DESCRIPTION
### Updates:
1) Use TalkExcelConfigData.json instead of talk data in mainQuestData
2) Added execute triggers when finishing talks. The old method will cause problem since execute triggers can come from talks that dont belong to any quest.
3) CONTENT_FINISH_PLOT should be updated by AddContentProgressReq sent by client, probably should not be handled on our end when quest and talks are finish. Otherwise it will for example teleport player back to scene 3 immediately after clearing dungeon in quest 307 before finishing the cutscene.